### PR TITLE
Add feature id007

### DIFF
--- a/api_test/src/test/java/ecse429/group7/BaseTest.java
+++ b/api_test/src/test/java/ecse429/group7/BaseTest.java
@@ -120,6 +120,14 @@ public class BaseTest {
         return null;
     }
 
+    public static JSONArray getProjectTasks(String projectName) {
+        JSONObject proj = findProjectByName(projectName);
+        if (proj == null) return null;
+        int id = proj.getInt("id");
+        return Unirest.get("/projects/" + id + "/tasks")
+                .asJson().getBody().getObject().getJSONArray("todos");
+    }
+
     public static int findIdFromTodoName(String todo_name) {
         JSONObject todo = findTodoByName(todo_name);
         if (todo == null) return -1;

--- a/api_test/src/test/java/ecse429/group7/BaseTest.java
+++ b/api_test/src/test/java/ecse429/group7/BaseTest.java
@@ -109,6 +109,17 @@ public class BaseTest {
         return null;
     }
 
+    public static JSONObject findProjectByName(String projectName) {
+        JSONObject response = Unirest.get("/projects").asJson().getBody().getObject();
+        for (Object proj : response.getJSONArray("projects")) {
+            JSONObject project = (JSONObject) proj;
+            if (project.getString("title").equals(projectName)) {
+                return project;
+            }
+         }
+        return null;
+    }
+
     public static int findIdFromTodoName(String todo_name) {
         JSONObject todo = findTodoByName(todo_name);
         if (todo == null) return -1;

--- a/api_test/src/test/resources/ecse429/group7/ID007_Query_incomplete_tasks_by_class.feature
+++ b/api_test/src/test/resources/ecse429/group7/ID007_Query_incomplete_tasks_by_class.feature
@@ -25,47 +25,43 @@ to help manage my time.
       | Finish sprint 2  | false      | Need to finish front end tests |
       | Write class test | false      | Mid november                   |
       And no todos are associated with 'FACC 400'
-#
-#  Scenario Outline: Request incomplete tasks for a course incomplete tasks (Normal flow)
-#    Given <projectTitle> is the title of a class on the system
-#      And the class with title <projectTitle> has outstanding tasks
-#     When the user requests the incomplete tasks for the course with title <projectTitle>
-#     Then <n> todos will be returned
-#      And each todo returned will be marked as done
-#      And each todo returned will be a task of the class with title <projectTitle>
-#    Examples:
-#      | projectTitle | n |
-#      | ECSE 429     | 2 |
-#      | ECSE 428     | 2 |
-#
-#  Scenario Outline: Request incomplete tasks for a course with no incomplete tasks (Alternate flow)
-#    Given <projectTitle> is the title of a class on the system
-#      And the class with title <projectTitle> has no outstanding tasks
-#     When the user requests the incomplete tasks for the course with title <projectTitle>
-#     Then 0 todos will be returned
-#    Examples:
-#      | projectTitle |
-#      | ECSE 444     |
-#
-#  Scenario Outline: Request incomplete tasks for a course with no tasks (Alternate flow)
-#    Given <projectTitle> is the title of a class on the system
-#      And the class with title <projectTitle> has no tasks
-#     When the user requests the incomplete tasks for the course with title <projectTitle>
-#     Then 0 todos will be returned
-#    Examples:
-#      | projectTitle |
-#      | FACC 400     |
-#
-#  Scenario Outline: Request incomplete tasks for a course not registered on the system (Error flow)
-#    Given <projectTitle> is not a title of a class on the system
-#     When the user requests the incomplete tasks for the course with title <projectTitle>
-#     Then 0 todos will be returned
-#      And the user will receive an error telling them that the task doesn't exist on the system
-#    Examples:
-#      | projectTitle |
-#      | FACC 100      |
-#      | Doesn't exist |
-#
-#
-  Scenario: Dummy
-    Given the API server is running
+
+  Scenario Outline: Request incomplete tasks for a course incomplete tasks (Normal flow)
+    Given <projectTitle> is the title of a class on the system
+      And the class with title <projectTitle> has outstanding tasks
+     When the user requests the incomplete tasks for the course with title <projectTitle>
+     Then <n> todos will be returned
+      And each todo returned will be marked as done
+      And each todo returned will be a task of the class with title <projectTitle>
+    Examples:
+      | projectTitle | n |
+      | ECSE 429     | 2 |
+      | ECSE 428     | 2 |
+
+  Scenario Outline: Request incomplete tasks for a course with no incomplete tasks (Alternate flow)
+    Given <projectTitle> is the title of a class on the system
+      And the class with title <projectTitle> has no outstanding tasks
+     When the user requests the incomplete tasks for the course with title <projectTitle>
+     Then 0 todos will be returned
+    Examples:
+      | projectTitle |
+      | ECSE 444     |
+
+  Scenario Outline: Request incomplete tasks for a course with no tasks (Alternate flow)
+    Given <projectTitle> is the title of a class on the system
+      And the class with title <projectTitle> has no tasks
+     When the user requests the incomplete tasks for the course with title <projectTitle>
+     Then 0 todos will be returned
+    Examples:
+      | projectTitle |
+      | FACC 400     |
+
+  Scenario Outline: Request incomplete tasks for a course not registered on the system (Error flow)
+    Given <projectTitle> is not a title of a class on the system
+     When the user requests the incomplete tasks for the course with title <projectTitle>
+     Then 0 todos will be returned
+      And the user will receive an error telling them that the course doesn't exist on the system
+    Examples:
+      | projectTitle  |
+      | FACC 100      |
+      | Doesn't exist |

--- a/api_test/src/test/resources/ecse429/group7/ID007_Query_incomplete_tasks_by_class.feature
+++ b/api_test/src/test/resources/ecse429/group7/ID007_Query_incomplete_tasks_by_class.feature
@@ -1,30 +1,30 @@
-#Feature:
-#As a student,
-#I query the incomplete tasks for a class I am taking,
-#to help manage my time.
-#
-#  Background:
-#    Given the following projects exist on the system
-#      | title    | completed | active | description            |
-#      | ECSE 429 | false     | true   | Software validiation   |
-#      | ECSE 444 | true      | false  | Microprocessors        |
-#      | ECSE 428 | false     | false  | Software Eng. Practice |
-#      | FACC 400 | false     | false  | A do nothing class     |
-#      And the following todos are associated with 'ECSE 429'
-#      | title                           | doneStatus | description              |
-#      | Complete feature files          | false      | includes this task       |
-#      | Finish project part A           | true       | exploratory & unit tests |
-#      | Add unit tests to feature files | false      | Use cucumber             |
-#      And the following todos are associated with 'ECSE 444'
-#      | title               | doneStatus | description       |
-#      | Complete labs       | true       | includes lab 1-7  |
-#      | Complete quizzes    | true       | includes quiz 1-6 |
-#      | Complete final proj | true       | driving game      |
-#      And the following todos are associated with 'ECSE 428'
-#      | title            | doneStatus | description                    |
-#      | Finish sprint 2  | false      | Need to finish front end tests |
-#      | Write class test | false      | Mid november                   |
-#      And no todos are associated with FACC 400
+Feature:
+As a student,
+I query the incomplete tasks for a class I am taking,
+to help manage my time.
+
+  Background:
+    Given the following projects exist on the system
+      | title    | completed | active | description            |
+      | ECSE 429 | false     | true   | Software validiation   |
+      | ECSE 444 | true      | false  | Microprocessors        |
+      | ECSE 428 | false     | false  | Software Eng. Practice |
+      | FACC 400 | false     | false  | A do nothing class     |
+      And the following todos are associated with 'ECSE 429'
+      | title                           | doneStatus | description              |
+      | Complete feature files          | false      | includes this task       |
+      | Finish project part A           | true       | exploratory & unit tests |
+      | Add unit tests to feature files | false      | Use cucumber             |
+      And the following todos are associated with 'ECSE 444'
+      | title               | doneStatus | description       |
+      | Complete labs       | true       | includes lab 1-7  |
+      | Complete quizzes    | true       | includes quiz 1-6 |
+      | Complete final proj | true       | driving game      |
+      And the following todos are associated with 'ECSE 428'
+      | title            | doneStatus | description                    |
+      | Finish sprint 2  | false      | Need to finish front end tests |
+      | Write class test | false      | Mid november                   |
+      And no todos are associated with 'FACC 400'
 #
 #  Scenario Outline: Request incomplete tasks for a course incomplete tasks (Normal flow)
 #    Given <projectTitle> is the title of a class on the system
@@ -67,3 +67,5 @@
 #      | Doesn't exist |
 #
 #
+  Scenario: Dummy
+    Given the API server is running

--- a/api_test/src/test/resources/ecse429/group7/ID007_Query_incomplete_tasks_by_class.feature
+++ b/api_test/src/test/resources/ecse429/group7/ID007_Query_incomplete_tasks_by_class.feature
@@ -1,0 +1,69 @@
+#Feature:
+#As a student,
+#I query the incomplete tasks for a class I am taking,
+#to help manage my time.
+#
+#  Background:
+#    Given the following projects exist on the system
+#      | title    | completed | active | description            |
+#      | ECSE 429 | false     | true   | Software validiation   |
+#      | ECSE 444 | true      | false  | Microprocessors        |
+#      | ECSE 428 | false     | false  | Software Eng. Practice |
+#      | FACC 400 | false     | false  | A do nothing class     |
+#      And the following todos are associated with 'ECSE 429'
+#      | title                           | doneStatus | description              |
+#      | Complete feature files          | false      | includes this task       |
+#      | Finish project part A           | true       | exploratory & unit tests |
+#      | Add unit tests to feature files | false      | Use cucumber             |
+#      And the following todos are associated with 'ECSE 444'
+#      | title               | doneStatus | description       |
+#      | Complete labs       | true       | includes lab 1-7  |
+#      | Complete quizzes    | true       | includes quiz 1-6 |
+#      | Complete final proj | true       | driving game      |
+#      And the following todos are associated with 'ECSE 428'
+#      | title            | doneStatus | description                    |
+#      | Finish sprint 2  | false      | Need to finish front end tests |
+#      | Write class test | false      | Mid november                   |
+#      And no todos are associated with FACC 400
+#
+#  Scenario Outline: Request incomplete tasks for a course incomplete tasks (Normal flow)
+#    Given <projectTitle> is the title of a class on the system
+#      And the class with title <projectTitle> has outstanding tasks
+#     When the user requests the incomplete tasks for the course with title <projectTitle>
+#     Then <n> todos will be returned
+#      And each todo returned will be marked as done
+#      And each todo returned will be a task of the class with title <projectTitle>
+#    Examples:
+#      | projectTitle | n |
+#      | ECSE 429     | 2 |
+#      | ECSE 428     | 2 |
+#
+#  Scenario Outline: Request incomplete tasks for a course with no incomplete tasks (Alternate flow)
+#    Given <projectTitle> is the title of a class on the system
+#      And the class with title <projectTitle> has no outstanding tasks
+#     When the user requests the incomplete tasks for the course with title <projectTitle>
+#     Then 0 todos will be returned
+#    Examples:
+#      | projectTitle |
+#      | ECSE 444     |
+#
+#  Scenario Outline: Request incomplete tasks for a course with no tasks (Alternate flow)
+#    Given <projectTitle> is the title of a class on the system
+#      And the class with title <projectTitle> has no tasks
+#     When the user requests the incomplete tasks for the course with title <projectTitle>
+#     Then 0 todos will be returned
+#    Examples:
+#      | projectTitle |
+#      | FACC 400     |
+#
+#  Scenario Outline: Request incomplete tasks for a course not registered on the system (Error flow)
+#    Given <projectTitle> is not a title of a class on the system
+#     When the user requests the incomplete tasks for the course with title <projectTitle>
+#     Then 0 todos will be returned
+#      And the user will receive an error telling them that the task doesn't exist on the system
+#    Examples:
+#      | projectTitle |
+#      | FACC 100      |
+#      | Doesn't exist |
+#
+#


### PR DESCRIPTION
There is one issue that I'm trying to figure out what to do with -- when getting outstanding tasks for a non-existent course, I specify `the user will receive an error telling them that the course doesn't exist on the system`. However, no such error is returned, since when the course doesn't exist, it just returns all tasks on the system. Not sure if I should update the feature, update the step to allow a failure (and document the failure as intentional, which I dislike b/c it would cause build issues), or something else. LMK your thoughts.